### PR TITLE
Fix xml output

### DIFF
--- a/lint/linter/PhpstanLinter.php
+++ b/lint/linter/PhpstanLinter.php
@@ -153,6 +153,7 @@ final class PhpstanLinter extends ArcanistExternalLinter
     {
         $result = array();
         if (!empty($stdout)) {
+            $stdout = substr($stdout, strpos($stdout, '<?xml'));
             $checkstyleOutpout = new SimpleXMLElement($stdout);
             $errors = $checkstyleOutpout->xpath('//file/error');
             foreach($errors as $error) {

--- a/lint/linter/PhpstanLinter.php
+++ b/lint/linter/PhpstanLinter.php
@@ -87,7 +87,7 @@ final class PhpstanLinter extends ArcanistExternalLinter
         $flags = array(
             'analyse',
             '--no-progress',
-            '--errorFormat=raw'
+            '--errorFormat=checkstyle'
         );
         if (null !== $this->configFile) {
             array_push($flags, '-c', $this->configFile);


### PR DESCRIPTION
Trim notes and make output checkstyle

Note example:
 ! [NOTE] PHPStan crashed in the previous run probably because of excessive memory consumption.
 !        It consumed around 32 MB of memory.
 !
 !        To avoid this issue, allow to use more memory with the --memory-limit option.
