### PR TITLE
Update phpstan version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
   "prefer-stable": true,
   "require": {
     "php": "^5.6 || ^7.0",
-    "phpstan/phpstan": "^0.9"
+    "phpstan/phpstan": "^0.11"
   }
 }


### PR DESCRIPTION
Now you cannot install this package with actual PHPstan version (0.11.6):

```
$ composer require appsinet/arc-phpstan
Using version ^1.0 for appsinet/arc-phpstan
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - appsinet/arc-phpstan v1.0.1 requires phpstan/phpstan ^0.9 -> satisfiable by phpstan/phpstan[0.9, 0.9.1, 0.9.2] but these conflict with your requirements or minimum-stability.
    - appsinet/arc-phpstan v1.0.0 requires phpstan/phpstan ^0.9 -> satisfiable by phpstan/phpstan[0.9, 0.9.1, 0.9.2] but these conflict with your requirements or minimum-stability.
    - Installation request for appsinet/arc-phpstan ^1.0 -> satisfiable by appsinet/arc-phpstan[v1.0.0, v1.0.1].


Installation failed, reverting ./composer.json to its original content.
```

I have updated phpstan dependency version. 

After merge, please tag new version too. Thank you