### PR TITLE
Level is not "MAX" by default anymore.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To use the linter you must register it in your `.arclint` file, as in this examp
       "include": "(\\.php$)",
       "config": "var/build/phpstan.neon", /* optional */
       "bin": "vendor/bin/phpstan", /* optional */
-      "level": 0 /* optional */
+      "level": "0" /* optional */
     }
   }
 }

--- a/lint/linter/PhpstanLinter.php
+++ b/lint/linter/PhpstanLinter.php
@@ -27,7 +27,7 @@ final class PhpstanLinter extends ArcanistExternalLinter
     /**
      * @var string Rule level
      */
-    private $level = 'max';
+    private $level = null;
 
     /**
      * @var string Autoload file path
@@ -112,7 +112,7 @@ final class PhpstanLinter extends ArcanistExternalLinter
                 ),
             ),
             'level' => array(
-                'type' => 'optional int',
+                'type' => 'optional string',
                 'help' => pht(
                     'Rule level used (0 loosest - max strictest). Will be provided as -l <level> to phpstan.'
                 ),


### PR DESCRIPTION
There were some inconsistent behaviour around `level` parameter.

1) Default value was "max" but in `getMandatoryFlags()` it was compared to `null`. So if you skipped this option in your `.arclint` file you got automagically level "max" instead of level from your config file. 

2) Level was marked as "optional int" in `getLinterConfigurationOptions()` but possible values are 0-7 and "max". I change it to "optional string".

---

It can cause BC break for someone who had `.arclint` configuration without level configuration. After this patch phpstan will be called with level from config file or PHPStan default value (0).