### PR TITLE
Lint dependent files too

### DIFF
--- a/lint/linter/PhpstanLinter.php
+++ b/lint/linter/PhpstanLinter.php
@@ -301,7 +301,9 @@ final class PhpstanLinter extends ArcanistExternalLinter
         foreach ($paths as $pathToLint) {
             $fullPathToLint = Filesystem::resolvePath($pathToLint, $root);
 
-            $additionalPaths = array_merge($additionalPaths, $dependencies->$fullPathToLint);
+            if (property_exists($dependencies, $fullPathToLint)) {
+                $additionalPaths = array_merge($additionalPaths, $dependencies->$fullPathToLint);
+            }
         }
 
         $additionalPaths = array_unique($additionalPaths);


### PR DESCRIPTION
`arc-phpstan` have had serious problem with not matching all problems in codebase. It is because arcanist call linters only with changed files. This is absolutely OK when you linting something easy like formatting. But static analysis is much more complex.

For example when you add new mandatory parameter to method and you do not change all places where you call this method, you want to PHPStan find this bug. But to find this PHPStan needs analyse all files where method is used not only changed file. Without analysing dependent files PHPStan cannot find this bug. You can feel safe because no errors in static analyse and problem will be found by customers. This is really bad.

How to solve it? You can run PHPStan over whole project but it is slow. There is another way too. PHPStan can give you list of dependent files for every class. You can get it with `phpstan dump-deps`. With this list of dependent files we can add dependent files to analyse. This is faster than running PHPStan over all files in project and you can be sure that analyse not missed any error.
